### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ scikit_learn>=0.19
 tensorboardX>=1.1
 typing>=3.6
 PyYAML>=3.12
-fuzzywuzzy>=0.16
-python-Levenshtein
+rapidfuzz>=0.3.0
 category_encoders
 torch>=0.4.0
 torchvision

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=["isoweek", "tqdm", "bcolz", "kaggle_data", "opencv_python", "torch", "torchvision",
                       "tensorflow-gpu", "scikit_image", "setuptools", "numpy", "matplotlib", "scipy", "Pillow",
                       "scikit_learn", "tensorboardX", "typing", "PyYAML", "Augmentor", "feather-format",
-                      "fuzzywuzzy", "python-Levenshtein", "category_encoders",
+                      "rapidfuzz", "category_encoders",
                       find_packages(exclude=["*.tests", "*.tests.*", "tests.*",
                                              "tests", "torchlite.*", "torchvision.*"])],
 )

--- a/torchlite/pandas/cleaner.py
+++ b/torchlite/pandas/cleaner.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import numpy as np
 from pandas.api.types import is_numeric_dtype, is_float_dtype, is_integer_dtype
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 
 
 def replace_matches_in_column(df, column, string_to_match, min_ratio=90, limit=10):


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy